### PR TITLE
fix command error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN \
     rrdtool net-snmp net-snmp-utils cronie mariadb autoconf \
     bison openssl openldap mod_ssl net-snmp-libs automake \
     gcc gzip libtool make net-snmp-devel dos2unix m4 which \
-    openssl-devel mariadb-devel sendmail curl wget help2man perl-libwww-perl && \
+    openssl-devel mariadb-devel sendmail curl wget help2man perl-libwww-perl procps-ng && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \
     echo "ServerName localhost" > /etc/httpd/conf.d/fqdn.conf && \


### PR DESCRIPTION
error detected.

```
tail -f /cacti/log/cacti_stderr.log
sh: ps: command not found
env: 'uptime': No such file or directory
```